### PR TITLE
removes deprecated genMockFn calls

### DIFF
--- a/src/mocks.js
+++ b/src/mocks.js
@@ -3,21 +3,21 @@ module.exports = {
     jest.mock('Linking', () => ({
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
-      openURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
-      canOpenURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
-      getInitialURL: jest.genMockFn().mockReturnValue(Promise.resolve()),
+      openURL: jest.fn(() => Promise.resolve()),
+      canOpenURL: jest.fn(() => Promise.resolve()),
+      getInitialURL: jest.fn(() => Promise.resolve()),
     }));
 
     jest.mock('NetInfo', () => {
       return {
         isConnected: {
           fetch: () => {
-            return new Promise((accept, resolve) => {
+            return new Promise((accept) => {
               accept(true);
-            })
+            });
           }
         }
-      }
+      };
     });
 
     global.navigator = {
@@ -32,6 +32,6 @@ module.exports = {
     jest.mock('ScrollView', () => jest.genMockFromModule('ScrollView'));
     jest.mock('YellowBox', () => jest.genMockFromModule('YellowBox'));
 
-    console.error = jest.genMockFn();
+    console.error = jest.fn();
   }
 };


### PR DESCRIPTION
What?: Replaces `jest.genMockFn` with `jest.fn`.
Why?: Jest [removed `genMockFn` entirely in version 23.0.0](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2300) and the latest react-native version upgrades jest to 23+