### PR TITLE
Add react-native-localize

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Mocks currently included:
 * Linking
 * ScrollView
 * YellowBox
+* `react-native-localize`
 * console.error: This is currently included to avoid some warnings from react-navigation.
 
 ## License

--- a/src/mocks.js
+++ b/src/mocks.js
@@ -32,6 +32,46 @@ module.exports = {
     jest.mock('ScrollView', () => jest.genMockFromModule('ScrollView'));
     jest.mock('YellowBox', () => jest.genMockFromModule('YellowBox'));
 
+    //* react-native-localize
+    const getLocales = () => [
+      { countryCode: 'US', languageTag: 'en-US', languageCode: 'en', isRTL: false },
+      { countryCode: 'FR', languageTag: 'fr-FR', languageCode: 'fr', isRTL: false }
+    ];
+
+    const findBestAvailableLanguage = () => ({
+      languageTag: 'en-US',
+      isRTL: false
+    });
+
+    const getNumberFormatSettings = () => ({
+      decimalSeparator: '.',
+      groupingSeparator: ','
+    });
+
+    const getCalendar = () => 'gregorian';
+    const getCountry = () => 'US';
+    const getCurrencies = () => ['USD', 'EUR'];
+    const getTemperatureUnit = () => 'celsius';
+    const getTimeZone = () => 'Europe/Paris';
+    const uses24HourClock = () => true;
+    const usesMetricSystem = () => true;
+
+    const addEventListener = jest.fn();
+    const removeEventListener = jest.fn();
+
+    jest.mock('findBestAvailableLanguage', findBestAvailableLanguage);
+    jest.mock('getLocales', getLocales);
+    jest.mock('getNumberFormatSettings', getNumberFormatSettings);
+    jest.mock('getCalendar', getCalendar);
+    jest.mock('getCountry', getCountry);
+    jest.mock('getCurrencies', getCurrencies);
+    jest.mock('getTemperatureUnit', getTemperatureUnit);
+    jest.mock('getTimeZone', getTimeZone);
+    jest.mock('uses24HourClock', uses24HourClock);
+    jest.mock('usesMetricSystem', usesMetricSystem);
+    jest.mock('addEventListener', addEventListener);
+    jest.mock('removeEventListener', removeEventListener);
+
     console.error = jest.fn();
   }
 };


### PR DESCRIPTION
- Adds the basic mock for `react-native-localize`.

In order to make it more scalable, it would probably require that we let users config some of these variables, but as it is it will probably work for most users.
